### PR TITLE
Add type specification to `source_link()` call

### DIFF
--- a/R/msmb_html.R
+++ b/R/msmb_html.R
@@ -322,7 +322,7 @@ msmb_build_chapter = function(
         chapter,
         '<p style="text-align: center;">',
         bookdown:::button_link(link_prev, 'Previous'),
-        bookdown:::source_link(rmd_cur),
+        bookdown:::source_link(rmd_cur, 'view'),
         bookdown:::button_link(link_next, 'Next'),
         '</p>',
         '<p class="build-date">Page built: ', as.character(Sys.Date()), ' using ', R.version.string, '</p>',


### PR DESCRIPTION
This fixes the package for use with R 4.3+ by adding a `type='view'` argument to the `source_link()` call in the `msmb_build_chapter` function. This fixes an error `Error in load_config()[[type]] : missing subscript` that occurs when using the package in R 4.3+.